### PR TITLE
Make session optional in SessionProvider

### DIFF
--- a/src/GreenfinityNext_NextAuth.res
+++ b/src/GreenfinityNext_NextAuth.res
@@ -18,7 +18,7 @@ type authOptions
 module SessionProvider = {
   @module("next-auth/react") @react.component
   external make: (
-    ~session: sessionData,
+    ~session: sessionData=?,
     ~refetchInterval: int=?,
     ~children: 'children=?,
   ) => React.element = "SessionProvider"


### PR DESCRIPTION
This allows providing a session from the layouts and also work in case a page does not require authentication.