### PR TITLE
Extend support for Navigation, Navigation.Router, Font, Cache

### DIFF
--- a/src/GreenfinityNext.res
+++ b/src/GreenfinityNext.res
@@ -9,3 +9,5 @@ module Navigation = GreenfinityNext_Navigation
 module NextAuth = GreenfinityNext_NextAuth
 module Url = GreenfinityNext_Url
 module NextServer = GreenfinityNext_NextServer
+module Font = GreenfinityNext_Font
+module Cache = GreenfinityNext_Cache

--- a/src/GreenfinityNext_Cache.res
+++ b/src/GreenfinityNext_Cache.res
@@ -1,0 +1,4 @@
+type cacheType = [#page | #layout]
+
+@module("next/cache")
+external revalidatePath: (string, ~_type: cacheType=?) => unit = "revalidatePath"

--- a/src/GreenfinityNext_Font.res
+++ b/src/GreenfinityNext_Font.res
@@ -1,0 +1,5 @@
+type t = {variable: string}
+type fonts = array<t>
+
+let classNameOfFonts = fonts =>
+  fonts->Belt.Array.map(font => font.variable)->Js.Array2.joinWith(" ")

--- a/src/GreenfinityNext_Navigation.res
+++ b/src/GreenfinityNext_Navigation.res
@@ -5,6 +5,16 @@ open GreenfinityNext_Url
 type \"type" = [#replace | #push]
 @module("next/navigation")
 external redirect: (string, ~\"type": \"type"=?, unit) => unit = "redirect"
+@module("next/navigation")
+external notFound: unit => unit = "notFound"
+@module("next/navigation")
+external useSelectedLayoutSegment: (~parallelRoutesKey: string=?) => string =
+  "useSelectedLayoutSegment"
+@module("next/navigation")
+external useSelectedLayoutSegments: (~parallelRoutesKey: string=?) => array<string> =
+  "useSelectedLayoutSegments"
+@module("next/navigation")
+external usePathname: unit => string = "usePathname"
 
 module Router = {
   type t = {
@@ -20,9 +30,20 @@ module Router = {
   @module("next/navigation")
   external useSearchParams: unit => URLSearchParams.t = "useSearchParams"
 
-  @send external push: (t, string) => unit = "push"
-  @send external pushObj: (t, GreenfinityNext_Next.Router.pathObj) => unit = "push"
+  type options = {scroll?: bool}
 
-  @send external replace: (t, string) => unit = "replace"
-  @send external replaceObj: (t, GreenfinityNext_Next.Router.pathObj) => unit = "replace"
+  @send external push: (t, string, ~options: options=?) => unit = "push"
+  @send
+  external pushObj: (t, GreenfinityNext_Next.Router.pathObj, ~options: options=?) => unit = "push"
+
+  @send external replace: (t, string, ~options: options=?) => unit = "replace"
+  @send
+  external replaceObj: (t, GreenfinityNext_Next.Router.pathObj, ~options: options=?) => unit =
+    "replace"
+
+  @send external back: t => unit = "back"
+  @send external forward: t => unit = "forward"
+
+  @send external refresh: t => unit = "refresh"
+  @send external prefetch: (t, string) => unit = "prefetch"
 }

--- a/src/GreenfinityNext_Next.res
+++ b/src/GreenfinityNext_Next.res
@@ -126,6 +126,7 @@ module Link = {
     ~passHref: option<bool>=?,
     ~children: React.element,
     ~className: string=?,
+    ~scroll: bool=?,
   ) => React.element = "default"
 }
 


### PR DESCRIPTION
- Add more methods for navigation
  - notFound
  - useSelectedLayoutSegment
  - useSelectedLayoutSegments
  - usePathname
  - add  to navigation methods
- Add scroll option to Link
- Add methods for router
  - back 
  - forward
  - push with options={scroll:false}
  - replace with options={scroll:false}
  - refresh
  - prefetch
- Add support for next/font
  - classNameOfFonts to allow injection to html tag
- Add support for next/cache
  - revalidatePath