### PR TITLE
Amend Next.Headers and NextRequest

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -11,14 +11,20 @@
       "subdirs": true
     }
   ],
-  "jsx": { "version": 4, "mode": "classic" },
+  "jsx": {
+    "version": 4,
+    "mode": "classic"
+  },
   "warnings": {
     "error": "+101"
   },
   "refmt": 3,
   "suffix": ".bs.js",
   "namespace": false,
-  "bsc-flags": ["-bs-super-errors", "-bs-no-version-header"],
+  "bsc-flags": [
+    "-bs-super-errors",
+    "-bs-no-version-header"
+  ],
   "package-specs": [
     {
       "module": "commonjs",
@@ -30,6 +36,11 @@
     "rescript-logger",
     "@greenlabs/ppx-spice"
   ],
-  "ppx-flags": ["rescript-logger/ppx", "@greenlabs/ppx-spice/ppx"],
-  "bs-dev-dependencies": ["@glennsl/rescript-jest"]
+  "ppx-flags": [
+    "rescript-logger/ppx",
+    "@greenlabs/ppx-spice/ppx"
+  ],
+  "bs-dev-dependencies": [
+    "@glennsl/rescript-jest"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
     },
     "rescript-logger@3.1.0": {
       "unplugged": true
+    },
+    "rescript-logger@4.0.0": {
+      "unplugged": true
     }
   },
   "dependencies": {

--- a/src/GreenfinityNext_Next.mjs
+++ b/src/GreenfinityNext_Next.mjs
@@ -1,0 +1,4 @@
+
+// workaround for "cannot be used from client component" error
+export const headersMakeWithRequire = () =>
+    require('next/headers').headers()

--- a/src/GreenfinityNext_Next.res
+++ b/src/GreenfinityNext_Next.res
@@ -216,7 +216,6 @@ module Script = {
 }
 */
 
-
 /*
 // https://nextjs.org/docs/advanced-features/custom-error-page#reusing-the-built-in-error-page
 module Error = {
@@ -301,7 +300,7 @@ module Image = {
     ~layout: [#fixed | #intrinsic | #responsive | #fill]=?,
     ~loader: loaderOptions => string=?,
     ~loading: [
-      | #"lazy"
+      | @as("lazy") #lazy_
       | #eager
     ]=?,
     ~priority: bool=?,
@@ -324,6 +323,9 @@ module Image = {
 module Headers = {
   type t
   @new @module("next/headers") external make: unit => t = "headers"
+  // workaround for "cannot be used from client component" error
+  @module("./GreenfinityNext_Next")
+  external makeWithRequire: unit => t = "headersMakeWithRequire"
   @send external _get: (t, string) => Js.Nullable.t<string> = "get"
   let get = (headers, k) => headers->_get(k)->Js.Nullable.toOption
   @send external keys: t => Js.Array.array_like<string> = "keys"

--- a/src/GreenfinityNext_NextServer.res
+++ b/src/GreenfinityNext_NextServer.res
@@ -1,10 +1,27 @@
-open GreenfinityNext_Next
-
 // --
 // app routes support
 // --
 
 module NextRequest = {
+  module Cookies = {
+    type t
+    @send external set: (t, string, string) => unit = "set"
+    @send external get: (t, string) => string = "get"
+    @send external getAll: t => Js.Dict.t<string> = "getAll"
+    @send external delete: (t, string) => unit = "delete"
+    @send external has: (t, string) => bool = "has"
+    @send external clear: t => unit = "clear"
+  }
+
+  module URL = {
+    type t = {
+      ...GreenfinityNext_Url.URL.t,
+      // According to the docs, these should exist:
+      // basePath: string,
+      // buildId?: string,
+    }
+  }
+
   type geo = {
     city: option<string>,
     country: option<string>,
@@ -14,9 +31,11 @@ module NextRequest = {
   }
 
   type t = {
-    headers: Headers.t,
+    headers: GreenfinityNext_Fetch.Headers.t,
     ip: option<string>,
     geo: geo,
+    nextUrl: URL.t,
+    cookies: Cookies.t,
   }
 
   @send external json: t => promise<Js.Json.t> = "json"
@@ -40,4 +59,8 @@ module NextResponse = {
   external make: ('a, ~options: options=?) => promise<t> = "NextResponse"
   @module("next/server") @scope("NextResponse")
   external json: (Js.Json.t, ~options: options=?) => promise<t> = "json"
+}
+
+module Middleware = {
+  type config = {matcher: array<string>}
 }

--- a/src/GreenfinityNext_Url.res
+++ b/src/GreenfinityNext_Url.res
@@ -1,4 +1,4 @@
-// Not strictlyr nextjs Url support
+// Not strictly nextjs Url support
 
 module SearchParams = {
   type value
@@ -22,7 +22,6 @@ module URLSearchParams = {
 }
 
 module URL = {
-  @deriving(abstract)
   type t = {
     hash: string,
     host: string,
@@ -37,5 +36,6 @@ module URL = {
     searchParams: URLSearchParams.t,
     username: string,
   }
+
   @new external make: string => t = "URL"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,8 @@ __metadata:
       unplugged: true
     rescript-logger@3.1.0:
       unplugged: true
+    rescript-logger@4.0.0:
+      unplugged: true
     rescript@10.1.4:
       unplugged: true
     rescript@11.0.0-rc.8:


### PR DESCRIPTION
- Next.Headers 
  - add Next.Headers.makeWithRequire as a workaround for the "must be used in client component" nextjs bug 
  - update for "lazy" reserved word
- NextRequest 
  - fix the type of NextRequest.headers 
  - add NextRequest.nextUrl
  - add NextRequest.cookies