### PR TITLE
Fix Headers.makeWithRequire external dependency

### DIFF
--- a/src/GreenfinityNext_Next.res
+++ b/src/GreenfinityNext_Next.res
@@ -324,7 +324,7 @@ module Headers = {
   type t
   @new @module("next/headers") external make: unit => t = "headers"
   // workaround for "cannot be used from client component" error
-  @module("./GreenfinityNext_Next")
+  @module("./GreenfinityNext_Next_raw")
   external makeWithRequire: unit => t = "headersMakeWithRequire"
   @send external _get: (t, string) => Js.Nullable.t<string> = "get"
   let get = (headers, k) => headers->_get(k)->Js.Nullable.toOption

--- a/src/GreenfinityNext_Next_raw.mjs
+++ b/src/GreenfinityNext_Next_raw.mjs
@@ -1,4 +1,3 @@
-
 // workaround for "cannot be used from client component" error
 export const headersMakeWithRequire = () =>
     require('next/headers').headers()


### PR DESCRIPTION
Importing the raw js caused an import error.